### PR TITLE
ci: Make workflows actually run

### DIFF
--- a/.github/workflows/addon-check.yml
+++ b/.github/workflows/addon-check.yml
@@ -2,6 +2,7 @@ name: Kodi
 on:
 - pull_request
 - push
+- workflow_dispatch
 jobs:
   tests:
     name: Addon checker

--- a/.github/workflows/addon-check.yml
+++ b/.github/workflows/addon-check.yml
@@ -30,8 +30,6 @@ jobs:
     - name: Rewrite addon.xml for Matrix
       run: |
         xmlstarlet ed -L -u '/addon/requires/import[@addon="xbmc.python"]/@version' -v "3.0.0" addon.xml
-        version=$(xmlstarlet sel -t -v 'string(/addon/@version)' addon.xml)
-        xmlstarlet ed -L -u '/addon/@version' -v "${version}+matrix.99" addon.xml
       working-directory: ${{ github.repository }}
       if: matrix.kodi-branch == 'matrix'
     - name: Run kodi-addon-checker

--- a/.github/workflows/addon-check.yml
+++ b/.github/workflows/addon-check.yml
@@ -12,11 +12,11 @@ jobs:
       matrix:
         kodi-branch: [krypton, leia, matrix]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         path: ${{ github.repository }}
     - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 on:
 - pull_request
 - push
+- workflow_dispatch
 jobs:
   tests:
     name: Add-on testing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
         python-version: [ 2.7, 3.5, 3.6, 3.7, 3.8 ]
     steps:
     - name: Check out ${{ github.sha }} from repository ${{ github.repository }}
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 coverage
 kodi-addon-checker
 pylint
-git+git://github.com/tamland/kodi-plugin-routing.git@master#egg=routing
+git+https://github.com/tamland/kodi-plugin-routing.git@master#egg=routing
 setuptools >= 41
 tox
 xmlschema == 1.0.18; python_version == '2.7'

--- a/resources/lib/addon.py
+++ b/resources/lib/addon.py
@@ -30,7 +30,7 @@ def years():
 
 
 def get_format():
-    return FORMATS[addon.getSettingInt('format')]
+    return FORMATS[addon.getSettingInt('format')]  # pylint: disable=no-member
 
 
 def get_metadata(event):

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -52,4 +52,4 @@ class TestRouting(unittest.TestCase):
     def test_show_event_fail(self):
         """Event: /event/2020/9604"""
         addon.run(['plugin://plugin.video.fosdem/event/2020/9604', '0', ''])
-        self.assertEqual(plugin.url_for(addon.show_event, year='2020', event_id='9604'), 'plugin://plugin.video.fosdem/event/2020/9604')
+        self.assertNotEqual(plugin.url_for(addon.show_event, year='2020', event_id='9604'), 'plugin://plugin.video.fosdem/event/2020/9604')


### PR DESCRIPTION
With the `workflow_dispatch` event you get the option to manually trigger the workflows to run.

EDIT: I added the following 2 commits with which the workflows actually run (but they still fail)
- ci: Update checkout and setup-python action to later version
- Change routing plugin url to use git+https instead of git+git